### PR TITLE
Fix modal download button

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,7 +384,7 @@
         <img id="displayImage" class="d-block mx-auto my-auto" alt="Image Preview">
       </div>
       <div class="modal-footer d-flex justify-content-between">
-        <span class="alert alert-warning">Right click on the image to download</span>
+        <a id="downloadImageButton" class="btn btn-outline-secondary">Download Image</a>
         <button type="button" class="btn btn-secondary" data-dismiss="modal">OK</button>
       </div>
     </div>

--- a/scripts/imageProcessor.js
+++ b/scripts/imageProcessor.js
@@ -84,18 +84,27 @@ function analyseImage(uid, image, area, palette, d3, dither) {
     $("#displayImage").attr('src', image.src)
       .height(image.height)
       .width(image.width);
+    var base64 = converted_image.replace('data:image/png;base64,', '');
+    $('#downloadImageButton').attr('href', image.src);
+    $('#downloadImageButton').attr('download', ($('#fnNameInput_000001').val() + '-original.png'));
     $("#imageDisplayModal").modal('show');
   });
   $("#viewResizedImgBtn_"+uid).click(function() {
     $("#displayImage").attr('src', resized_image)
       .height(h*dispScale)
       .width(w*dispScale);
+    var base64 = converted_image.replace('data:image/png;base64,', '');
+    $('#downloadImageButton').attr('href', resized_image);
+    $('#downloadImageButton').attr('download', ($('#fnNameInput_000001').val() + '-resized.png'));
     $("#imageDisplayModal").modal('show');
   });
   $("#viewFinalImgBtn_"+uid).click(function() {
     $("#displayImage").attr('src', converted_image)
       .height(h*dispScale)
       .width(w*dispScale);
+    var base64 = converted_image.replace('data:image/png;base64,', '');
+    $('#downloadImageButton').attr('href', converted_image);
+    $('#downloadImageButton').attr('download', ($('#fnNameInput_000001').val() + '-converted.png'));
     $("#imageDisplayModal").modal('show');
   })
 }
@@ -188,4 +197,3 @@ function indexOfArray(a, parent_arr) {
     }
   } //Arrays are in different variables -> normal comparison always false
 }
-

--- a/scripts/imageProcessor.js
+++ b/scripts/imageProcessor.js
@@ -84,7 +84,6 @@ function analyseImage(uid, image, area, palette, d3, dither) {
     $("#displayImage").attr('src', image.src)
       .height(image.height)
       .width(image.width);
-    var base64 = converted_image.replace('data:image/png;base64,', '');
     $('#downloadImageButton').attr('href', image.src);
     $('#downloadImageButton').attr('download', ($('#fnNameInput_000001').val() + '-original.png'));
     $("#imageDisplayModal").modal('show');
@@ -93,7 +92,6 @@ function analyseImage(uid, image, area, palette, d3, dither) {
     $("#displayImage").attr('src', resized_image)
       .height(h*dispScale)
       .width(w*dispScale);
-    var base64 = converted_image.replace('data:image/png;base64,', '');
     $('#downloadImageButton').attr('href', resized_image);
     $('#downloadImageButton').attr('download', ($('#fnNameInput_000001').val() + '-resized.png'));
     $("#imageDisplayModal").modal('show');
@@ -102,7 +100,6 @@ function analyseImage(uid, image, area, palette, d3, dither) {
     $("#displayImage").attr('src', converted_image)
       .height(h*dispScale)
       .width(w*dispScale);
-    var base64 = converted_image.replace('data:image/png;base64,', '');
     $('#downloadImageButton').attr('href', converted_image);
     $('#downloadImageButton').attr('download', ($('#fnNameInput_000001').val() + '-converted.png'));
     $("#imageDisplayModal").modal('show');


### PR DESCRIPTION
Hi there,

I was using your app today and I loved it! Very easy to use and helped me along with making a map art on Constantiam.net.

I only had one issue, which was the button in the bottom left of the preview modal. To me, a button should provide functionality. If a button doesn't provide functionality, it should only be temporary. The button in the modal acted more as an 'alert' or info message. Maybe I'm way too sensitive of a person, but it kind of annoyed me, haha. In my head, I was like, "Why is a button that I could click to download the image telling me to right-click? If I didn't see a button, I would have just done that anyway."

Anyway, in case there are any other weirdos out there like me, I thought this pull request might be useful. In essence, it turns the button telling me how to download the image to instead just outright download the image.

I can certainly make any changes you desire. I wasn't sure if the outline style of the button would work for you or not, so happy to tweak this to your preference.

Cheers,

Ian