### PR TITLE
Update Minecraft wiki references

### DIFF
--- a/manual.html
+++ b/manual.html
@@ -84,13 +84,13 @@
       lot !), so the commands are split into 2 sets per map and written into seperate function files (they are
       regular commands like <code>/setblock</code>, but Minecraft can then execute upto 10,000 (by default) of them 
       <em>at once</em> from these files). More instructions on running the functions are given <a href="#in-mc">below</a>.
-      <br><a href="https://minecraft.gamepedia.com/Function_(Bedrock_Edition)" rel="nofollow noreferrer">
+      <br><a href="https://minecraft.wiki/w/Function_(Bedrock_Edition)" rel="nofollow noreferrer">
       Read more</a> about functions in Minecraft.</li><br>
     <li> The converted images seen after you click the 'Process Image' button may vary slightly (especially in the "noise"
       generated due to Image Dithering) depending on your device / browser (Since part of the image resizing operations are
       performed by your browser). This is unavoidable. </li><br>
     <li> The commands use relative <b>&tilde;</b> (<a  rel="nofollow noreferrer"
-      href="https://minecraft.gamepedia.com/Commands#Relative_world_coordinates:_Tilde_notation">tilde notation</a>) to
+      href="https://minecraft.wiki/w/Coordinates#Relative_world_coordinates">tilde notation</a>) to
     specify the positon, so that the image can be built wherever you (the player, or a command block if you are using
     one) are located in your world when starting, instead of a specific area every time.</li><br>
     <li>For the 3D arrangement, the max height specification only ensures that blocks do not get
@@ -140,7 +140,7 @@
       in case they don't appear in the commands screen or minecraft hasn't recognised the functions <br> &nbsp;</li>
     <li><span class="lead" id="in-mc-done">You're Done !</span><p> Once you've constructed the image, map the entire area covered by it
       and build a map wall for your pixel art !<br> It's also a good idea to <a rel="nofollow noreferrer"
-      href="https://minecraft.gamepedia.com/Cartography_Table#Usage" >lock the maps</a> with glass panes to prevent them
+      href="https://minecraft.wiki/w/Cartography_Table#Usage" >lock the maps</a> with glass panes to prevent them
       from updating if some other structures are built above them, or if the colour palette changes in future updates.</p>
       <br/><p>
         <strong class="text-black">Note :</strong> If you see that many blocks are missing, especially in a zig-zag like pattern


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all references accordingly.