### PR TITLE
Add support for local storage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -161,3 +161,8 @@ table caption {
 #light-dark-toggle-label::after {
   top: calc(0.35em + 2px);
 }
+
+.text-info.text-info-inverted {
+  /* bootstrap marked it as important already */
+  color: white !important;
+}

--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
 <script src="scripts/theme_pwa.js"></script>
 <script src="resources/data.js"></script>
 <script src="scripts/main.js" defer></script>
+<script src="scripts/localStorage.js" defer></script>
 <script src="scripts/imageProcessor.js" defer></script>
 <script src="scripts/functionWriter.js" defer></script>
 <script src="scripts/dynamicHtml.js" defer></script>
@@ -141,7 +142,7 @@
           </div>
           <div class="form-check">
             <input type="checkbox" id="buildWithStructures" class="form-check-input" name="useStructuresOption" value="structs"/>
-            <label for="useStructuresOption" class="form-check-label"> Use only structures instead of the setblock command </label>
+            <label for="buildWithStructures" class="form-check-label"> Use only structures instead of the setblock command </label>
             <a data-toggle="tooltip" data-placement="top" class="text-info add-questionmark" aria-label="Explanation popup" data-html="true" 
             title="Use this to include all used blocks as structures and load them with the <code>/structure load</code> command instead
             of placing regular blocks with <code>/setblock</code>. This can avoid gaps in the map due to blocks not being placed outside 

--- a/resources/data.js
+++ b/resources/data.js
@@ -499,6 +499,11 @@ Colours.forEach(function(value, key) {
 const PictureData = {
     "000001": {
         originalImage: undefined,
+        originalFileName: undefined,
+        resizedImage: undefined,
+        originalWasResized: undefined,
+        fnName: undefined,
+        configurationDirty: true,
         finalImage: undefined,
         shadeMap: undefined
     }

--- a/scripts/dynamicHtml.js
+++ b/scripts/dynamicHtml.js
@@ -23,8 +23,8 @@ function makeTabLabelContent(uid, tabTitle = ""){
   if (tabSavedDataSize > 0) {
     let originalWasResized = getSavedFormOriginalWasResized(uid);
     let originalWasResizedTooltip = originalWasResized ? ` (stored resized image because original was too big; re-select the image to change area)` : "";
-    let originalWasResizedMarker = originalWasResized ? "🗛" : "";
-    tabSavedMarker = `<small title="Local storage: ${(tabSavedDataSize / 1024 + 1) | 0} kb${originalWasResizedTooltip}">&nbsp;💾${originalWasResizedMarker}</small>`;
+    let originalWasResizedMarker = originalWasResized ? "&nbsp;&nbsp;"+icons.shrink : "";
+    tabSavedMarker = `<small title="Local storage: ${(tabSavedDataSize / 1024 + 1) | 0} kb${originalWasResizedTooltip}">&nbsp;&nbsp;${icons.save}${originalWasResizedMarker}</small>`;
   }
   return `${tabTitle}${tabDirtyMarker}${tabSavedMarker}`;
 }
@@ -154,13 +154,14 @@ function newImageUpload(uid, {fnName = "", active = true} = {}) {
         <button class="btn btn-info font-weight-bold" id="viewFinalImgBtn_${uid}">Converted</button>
       </div>
     </div>
-    <div class="btn-group">
-      <button class="btn btn-info" id="saveFormDataBtn_${uid}">💾 Save
-      <a data-toggle="tooltip" data-placement="top" data-html="true" title="Save to the browser's local storage.
-        No data is sent to the server. Has limited storage capacity. Delete other images if you cannot save anymore."
-        data-delay="{&quot;show&quot;:100, &quot;hide&quot;:2000}"
-        class="text-info text-info-inverted">${icons.questionmark}</a></button>
-      <button class="btn btn-warning mr-sm-3" id="imgEditBtn_${uid}">Edit</button>
+    <div>
+      <button class="btn btn-info" id="saveFormDataBtn_${uid}">${icons.save} Save
+        <a data-toggle="tooltip" data-placement="top" data-html="true" title="Save to the browser's local storage.
+          No data is sent to the server. This form will be restored the next time you visit this site."
+          data-delay="{&quot;show&quot;:100, &quot;hide&quot;:2000}"
+          class="text-info text-info-inverted">&nbsp;${icons.questionmark}</a>
+      </button>
+      <button class="btn btn-warning mr-sm-3" id="imgEditBtn_${uid}">${icons.edit} Edit</button>
     </div>
   </div>
   </div>

--- a/scripts/imageProcessor.js
+++ b/scripts/imageProcessor.js
@@ -47,6 +47,7 @@ function analyseImage(uid, image, area, palette, d3, dither) {
   var converted_image = canv.toDataURL("image/png");
   ctx.clearRect(0, 0, w, h);
   // $("#imageForm_"+uid).data('finalimage', finalImgData);
+  PictureData[uid]['resizedImage'] = resized_image;
   PictureData[uid]['finalImage'] = finalImgData;
   
   // Processing done, configure the preview buttons

--- a/scripts/localStorage.js
+++ b/scripts/localStorage.js
@@ -1,0 +1,133 @@
+/*
+Minecraft Pixel Art Maker
+© gd-codes 2024
+https://gd-codes.github.io/mc-pixelart-maker/
+*/
+
+
+/**
+ * Saves the given form data to local storage.
+ * If the original image exceeds a certain size threshold, the resizedImage is saved in place of the originalImage.
+ * @param {string} uid - The form uid. Used as key to retrieve the form data later.
+ * @param {string} originalFileName - The file name.
+ * @param {string} originalImage - The data URL representing the original image.
+ * @param {string} resizedImage - The data URL representing the image resized to the map area.
+ * @param {boolean} originalWasResized - Whether the original image was already resized to a previous map area.
+ * @param {string} fnName - The function name.
+ * @param {Object} configuration - The form configuration. An arbitrary JSON-able object.
+ * @returns {boolean} - Whether saving the form data was successful.
+ */
+function saveFormData(uid, {
+  PictureDataForUid: {
+    originalFileName,
+    originalImage,
+    resizedImage,
+    originalWasResized
+  },
+  fnName,
+  configuration
+}) {
+
+  // We prefer to store the original, but if it exceeds the threshold and the resized is smaller than the original,
+  // we store the resized instead.
+  // In that case, we store the resized even if it exceeds the threshold.
+  let originalTooLarge = 1000000 < originalImage.length &&
+      resizedImage.length < originalImage.length;
+
+  // console.log("Saving form data; original image size: " + originalImage.length + "; resized image size: " + resizedImage.length)
+
+  let formDataString = JSON.stringify({
+    fnName: fnName,
+    originalFileName: originalFileName,
+    image: originalTooLarge ? resizedImage : originalImage,
+    originalWasResized: originalWasResized || originalTooLarge,
+    configuration: configuration
+  });
+
+  try {
+    // add or overwrite data for uid
+    localStorage.setItem("formData_" + uid, formDataString);
+  } catch (e) {
+    // assume quota exceeded
+    deleteSavedFormData(uid);
+    return false;
+  }
+
+  // add uid to the list of known uids
+  let uids = getStoredFormDataUids();
+  if (uids.indexOf(uid) < 0) {
+    uids.push(uid);
+    try {
+      localStorage.setItem("uids", JSON.stringify(uids));
+    } catch (e) {
+      // assume quota exceeded
+      deleteSavedFormData(uid);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Loads the previously saved form data from local storage.
+ * @param {string} uid - The uid of the form to load.
+ * @returns {{fnName: string, configuration: *, PictureDataForUid: {originalFileName: string, originalWasResized: boolean, originalImage: (string)}}|null} - the stored form data, or null
+ */
+function getSavedFormData(uid) {
+  let data = JSON.parse(localStorage.getItem("formData_" + uid) || "null");
+  if (!data) {
+    return null;
+  }
+  return {
+    fnName: data.fnName,
+    PictureDataForUid: {
+      originalImage: data.image,
+      originalFileName: data.originalFileName,
+      originalWasResized: data.originalWasResized
+    },
+    configuration: data.configuration
+  }
+}
+
+/**
+ * Returns the size of the form data stored for the given form uid.
+ * @param {string} uid - The form uid.
+ * @returns {number}
+ */
+function getSavedFormDataSize(uid) {
+  return (localStorage.getItem("formData_" + uid) || "").length;
+}
+
+/**
+ * Returns whether the form data saved for the uid contains a resized image.
+ * @param {string} uid - The form uid.
+ * @returns {boolean}
+ */
+function getSavedFormOriginalWasResized(uid) {
+  let data = JSON.parse(localStorage.getItem("formData_" + uid) || "null");
+  if (!data) {
+    return false;
+  }
+  return !!data.originalWasResized;
+}
+
+/**
+ * Deletes form data from local storage.
+ * @param {string} uid - The uid of the form to delete from local storage.
+ */
+function deleteSavedFormData(uid) {
+  let uids = getStoredFormDataUids().filter(function (v) {
+    return v !== uid;
+  });
+  localStorage.setItem("uids", JSON.stringify(uids));
+  localStorage.removeItem("formData_" + uid);
+}
+
+/**
+ * Returns the uids of all forms for which data is stored in local storage.
+ * @returns {Array<string>}
+ */
+function getStoredFormDataUids() {
+  return JSON.parse(localStorage.getItem("uids") || "[]");
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,14 +4,13 @@ Minecraft Pixel Art Maker
 https://gd-codes.github.io/mc-pixelart-maker/
 */
 const icons = {
-  square : "<svg width=\"1.0em\" height=\"1.0em\" viewBox=\"0 0 16 16\" class=\"bi bi-square-fill\" "+
-      "fill=\"currentColor\" xmlns=\"http://www.w3.org/2000/svg\" style=\"border: 1px solid black; border-radius: 15%;\">"+
-      "<path d=\"M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2z\"/></svg>",
-  square_noborder : "<svg width=\"1.0em\" height=\"1.0em\" viewBox=\"0 0 16 16\" class=\"bi bi-square-fill\" "+
-      "fill=\"currentColor\" xmlns=\"http://www.w3.org/2000/svg\">"+
-      "<path d=\"M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2z\"/></svg>",
-  questionmark : "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" fill=\"currentColor\" viewBox=\"0 0 16 16\" class=\"bi bi-question-circle\" > <path d=\"M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z\"/><path d=\"M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286zm1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z\"/></svg>",
-  infosquare : `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/></svg>`
+  square : `<svg width="1.0em" height="1.0em" viewBox="0 0 16 16" class="bi bi-square-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg" style="border: 1px solid black; border-radius: 15%;"><path d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2z"/></svg>`,
+  square_noborder : `<svg width="1.0em" height="1.0em" viewBox="0 0 16 16" class="bi bi-square-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2z"/></svg>`,
+  questionmark : `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" class="bi bi-question-circle" > <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/><path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286zm1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z"/></svg>`,
+  infosquare : `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/></svg>`,
+  save : `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-floppy2" viewBox="0 0 16 16"><path d="M1.5 0h11.586a1.5 1.5 0 0 1 1.06.44l1.415 1.414A1.5 1.5 0 0 1 16 2.914V14.5a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 0 14.5v-13A1.5 1.5 0 0 1 1.5 0M1 1.5v13a.5.5 0 0 0 .5.5H2v-4.5A1.5 1.5 0 0 1 3.5 9h9a1.5 1.5 0 0 1 1.5 1.5V15h.5a.5.5 0 0 0 .5-.5V2.914a.5.5 0 0 0-.146-.353l-1.415-1.415A.5.5 0 0 0 13.086 1H13v3.5A1.5 1.5 0 0 1 11.5 6h-7A1.5 1.5 0 0 1 3 4.5V1H1.5a.5.5 0 0 0-.5.5m9.5-.5a.5.5 0 0 0-.5.5v3a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 0-.5-.5z"/></svg>`,
+  edit : `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil" viewBox="0 0 16 16"><path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325"/></svg>`,
+  shrink : `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrows-angle-contract" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M.172 15.828a.5.5 0 0 0 .707 0l4.096-4.096V14.5a.5.5 0 1 0 1 0v-3.975a.5.5 0 0 0-.5-.5H1.5a.5.5 0 0 0 0 1h2.768L.172 15.121a.5.5 0 0 0 0 .707M15.828.172a.5.5 0 0 0-.707 0l-4.096 4.096V1.5a.5.5 0 1 0-1 0v3.975a.5.5 0 0 0 .5.5H14.5a.5.5 0 0 0 0-1h-2.768L15.828.879a.5.5 0 0 0 0-.707"/></svg>`
 };
 
 const default_palette = Array.from(Colours.keys()).join(' ');
@@ -285,8 +284,6 @@ function submitImgFormHandler(elem, event) {
       $("span[id='tabLabel_"+uid+"']").html(
           makeTabLabelContent(uid)
       );
-      $("#deleteBtn_"+uid).click( function(event){deleteImgForm(this);} );
-
       deleteSurvivalGuide(uid, true);
 
     } else {
@@ -323,7 +320,7 @@ function saveImgForm(uid) {
   if (success) {
     markDirty(uid, false);
   } else {
-    alert("Saving failed. Delete some other saved images and try again.");
+    alert("Saving failed - likely due to limited storage capacity. Delete some other saved images and try again.");
   }
 }
 

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@ https://gd-codes.github.io/mc-pixelart-maker/
 Cached site should require only ~ 3 MB space
 */
 
-const CURRENT_CACHE_VERSION = 'mapart-cache-4.5.0';
+const CURRENT_CACHE_VERSION = 'mapart-cache-4.6.0';
 
 const CACHE_URLS_LOCAL = [
     /* Important : `/` doesn't automatically fetch `/index.html` locally, explicitly cache it 


### PR DESCRIPTION
Fixes #14

* Implements storage of image tabs with all user-provided configuration.
* Converted image must be recomputed to save space.
* Saves the resized image if the original image is larger than 1MB in its base64 encoding.
* Added save button to save to local storage after successful conversion.
* Resetting a saved tab reverts to the saved state.
* Added a simple dirty state marker to tab header.
* Removing a tab also removes local storage for it.
