### PR TITLE
Survival Guide: add WASD keys, keep tooltip when browser tab loses focus

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -104,13 +104,17 @@ table caption {
   max-height: 1500;
 }
 
-.guide-tableareas td:focus {
+.guide-tableareas td.focused {
   -ms-transform: scale(1.5); 
   -moz-transform: scale(1.5); 
   -webkit-transform: scale(1.5); 
   -o-transform: scale(1.5);
   transform: scale(1.5);
-  border: medium solid black !important;
+}
+
+/* based on Chrome's "user agent stylesheet" for ":focus-visible" */
+.guide-tableareas td.focused {
+  outline: black auto 1px;
 }
 
 @media (max-width: 768px) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -827,6 +827,7 @@ function tableMovement(elem, event, verticalTab=false) {
   let vnext = lowerRow.length ? down : ( (i<63) ? tr.siblings().first().children()[i+1] : elem);
   let hprev = (i > 0) ? left : (upperRow.length? upperRow.children().last() : elem);
   let hnext = (i < 63) ? right : (lowerRow.length? lowerRow.children().first() : elem);
+  let handled = true;
   switch (event.code) {
     case 'Tab': 
       if (verticalTab.prop('checked')) {
@@ -835,12 +836,13 @@ function tableMovement(elem, event, verticalTab=false) {
         $(event.shiftKey? hprev : hnext).focus();
       }
       break;
-    case 'ArrowUp': $(up).focus(); break;
-    case 'ArrowDown': $(down).focus(); break;
-    case 'ArrowLeft': $(left).focus(); break;
-    case 'ArrowRight': $(right).focus(); break;
+    case 'ArrowUp': case 'KeyW': $(up).focus(); break;
+    case 'ArrowDown': case 'KeyS': $(down).focus(); break;
+    case 'ArrowLeft': case 'KeyA': $(left).focus(); break;
+    case 'ArrowRight': case 'KeyD': $(right).focus(); break;
+    default: handled = false; break;
   }
-  if (event.code === 'Tab' || event.code.slice(0,5) === 'Arrow') {
+  if (handled) {
     event.preventDefault();
   }
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -774,13 +774,17 @@ function createSurvivalGuide(uid, numzones) {
 
   /* Keeping 16,000+ popovers at once = horrible performance. 
   Hence create and destroy active one each time while focused */
+  let lastFocus;
   $(`.guide-tableareas td`).focus(function() {
+    if (lastFocus) {
+      $(lastFocus).popover('dispose');
+      $(lastFocus).removeData('toggle');
+      $(lastFocus).removeClass('focused');
+    }
+    $(this).addClass('focused');
     $(this).data('toggle', 'popover');
     $(this).popover('show');
-  });
-  $(`.guide-tableareas td`).blur(function() {
-    $(this).popover('dispose');
-    $(this).removeData('toggle');
+    lastFocus = this;
   });
 
   // Bind tab Direction modifier

--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -302,7 +302,7 @@ const EJStemplates = {
               <% let y = tabledatas[zone][z][x][1]; %>
               <% let pixnorm = ColourList[3*code]; %>
               <td tabindex="0" style="background-color: rgb(<%=pixnorm[0]%>,<%=pixnorm[1]%>,<%=pixnorm[2]%>);"
-                data-trigger="focus" data-placement="top" title="<%=MaterialNames[code]%>" data-html="true"
+                data-placement="top" title="<%=MaterialNames[code]%>" data-html="true"
                 data-content="Position : &lt;b&gt;~<%=x%> ~<%=y%> ~<%=z%>&lt;/b&gt;">
               </td>
             <% } %>


### PR DESCRIPTION
Fixes #27.

Here's my attempt at the WASD keys and persistent tooltip. It works for me (Chrome on Windows). Didn't test other browsers or platforms though.
