### PR TITLE
fix survival guide preferences label, add tooltip for colourPaletteIcon

### DIFF
--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -36,7 +36,7 @@ const EJStemplates = {
  * Note: Template must contain no newline or whitespaces!
  * @param {{rgb:[Number,Number,Number]}} colourdata
  */
-  colourPaletteIcon: `<span style="color:rgb(<%=colourdata.rgb[0]%>,<%=colourdata.rgb[1]%>,<%=colourdata.rgb[2]%>); padding: 2px;"><%-SVGicons.square_noborder%></span>`,
+  colourPaletteIcon: `<span title="<%=colourdata.name%>" style="color:rgb(<%=colourdata.rgb[0]%>,<%=colourdata.rgb[1]%>,<%=colourdata.rgb[2]%>); padding: 2px;"><%-SVGicons.square_noborder%></span>`,
   
   /** 
    * @param {String} uid

--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -250,7 +250,7 @@ const EJStemplates = {
     <label for="tabDirection_<%=uid%>">Enable Vertical <code>Tab</code> movement</label>
     <br/>
     <input type="checkbox" class="mx-2" id="guideTotalBlockCount_<%=uid%>" />
-    <label for="guideTotalBlockCoun>_<%=uid%>">View total count for all zones</label>
+    <label for="guideTotalBlockCount_<%=uid%>">View total count for all zones</label>
     <br/>
     <input type="checkbox" class="mx-2" id="guideStackViewCount_<%=uid%>" />
     <label for="guideStackViewCount_<%=uid%>">Display values in stacks of 64</label>


### PR DESCRIPTION
* Bug fix: One of the preferences labels has a typo and does not function as a clickable label.
* Improvement: Add tooltips for the colour palette icons.
