### PR TITLE
Add absolute coordinates

### DIFF
--- a/scripts/functionWriter.js
+++ b/scripts/functionWriter.js
@@ -138,12 +138,18 @@ function getSurvivalGuideTableData(uid) {
     cindexns.push(ColourTokens.indexOf(ct));
   }
 
+  // TODO make configurable and save with image configuration
+  // reference coordinates, i.e., absolute coordinates of the north-west corner of the overall map area
+  let referenceCoords = null; // {x:448, y:63, z:5312};
+
   return { uid: uid, 
     is3D: (ymax > 1), 
     numzones: zone_origins.length, 
     tabledatas:tabledatas, 
     blockcounts:blockcounts, 
-    cindexns:cindexns
+    cindexns:cindexns,
+    referenceCoords: referenceCoords,
+    zoneOrigins: zone_origins
   };
 }
 

--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -228,6 +228,8 @@ const EJStemplates = {
    * @param {Array<Array<Array<[Number,Number]>>>} tabledatas
    * @param {Array<Array<Number>>} blockcounts
    * @param {Array<Number>} cindexns
+   * @param {Array<Number> | null} referenceCoords optional
+   * @param {Array<Array<Number>>} zoneOrigins
    * @see getSurvivalGuideTableData()
    */
   survivalGuide: `
@@ -305,12 +307,15 @@ const EJStemplates = {
           <% for( let z = 0; z < 128; z++ ) { %>
             <tr>
             <% for( let x = 0; x < 64; x++ ) { %>
+              <% let zo = zoneOrigins[zone]; %>
               <% let code = tabledatas[zone][z][x][0]; %>
               <% let y = tabledatas[zone][z][x][1]; %>
               <% let pixnorm = ColourList[3*code]; %>
+              <% let absCoords = referenceCoords ? (referenceCoords.x+zo[0]+x) + " " + (referenceCoords.y+y) + " " + (referenceCoords.z+zo[1]+z) : ""; %>
               <td tabindex="0" style="background-color: rgb(<%=pixnorm[0]%>,<%=pixnorm[1]%>,<%=pixnorm[2]%>);"
                 data-placement="top" title="<%=MaterialNames[code]%>" data-html="true"
-                data-content="Position : &lt;b&gt;~<%=x%> ~<%=y%> ~<%=z%>&lt;/b&gt;">
+                data-content="Position: &lt;b&gt;~<%=x%> ~<%=y%> ~<%=z%>&lt;/b&gt;<% if (referenceCoords){ %>
+                &lt;br&gt;Coords: &lt;b&gt;<%=absCoords%>&lt;/b&gt;<% } %>">
               </td>
             <% } %>
             </tr>


### PR DESCRIPTION
Fixes #33.

Work in progress.

[x] Support rendering absolute coordinates in survival guide.
[ ] Add configuration option for reference coordinates (top-left map corner).
[ ] Save reference coordinates with image configuration.
